### PR TITLE
Network folder update

### DIFF
--- a/spring-boot-kafka-cluster/docker/application-consumer/docker-compose.yml
+++ b/spring-boot-kafka-cluster/docker/application-consumer/docker-compose.yml
@@ -38,4 +38,4 @@ services:
 networks:
   default:
     external:
-      name: kafka_default
+      name: docker_default

--- a/spring-boot-kafka-cluster/docker/application-producer/docker-compose.yml
+++ b/spring-boot-kafka-cluster/docker/application-producer/docker-compose.yml
@@ -13,4 +13,4 @@ services:
 networks:
   default:
     external:
-      name: kafka_default
+      name: docker_default

--- a/spring-boot-kafka-cluster/docker/kafka/docker-compose.yml
+++ b/spring-boot-kafka-cluster/docker/kafka/docker-compose.yml
@@ -117,4 +117,4 @@ services:
 networks:
   default:
     external:
-      name: kafka_default
+      name: docker_default


### PR DESCRIPTION
Network name start to get from parent folder, instead of kafka folder it starts to get it from docker folder.