### PR TITLE
Add dependebot to spring-boot-integration-test project.

### DIFF
--- a/spring-boot-integration-test/.github/dependabot.yml
+++ b/spring-boot-integration-test/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: org.springframework.boot
+    versions:
+    - 2.4.2
+  - dependency-name: org.testcontainers:postgresql
+    versions:
+    - 1.15.1
+  - dependency-name: org.postgresql:postgresql
+    versions:
+    - 42.2.18


### PR DESCRIPTION
- Add dependebot to spring-boot-integration-test project.